### PR TITLE
Rollback series rendering logic, remove series frontmatter

### DIFF
--- a/notes/socials/2025-07-12 Hearts in San Francisco statues.md
+++ b/notes/socials/2025-07-12 Hearts in San Francisco statues.md
@@ -1,7 +1,6 @@
 ---
 title: "Hearts in San Francisco - 100+ large statues"
 pubDate: July 12, 2025
-series: hearts-in-san-francisco
 alsoOn:
   - https://www.threads.com/@frankpuf/post/DMBxibwM2Jd
   - https://x.com/puf/status/1944190687097799054

--- a/notes/socials/2025-08-03 Hearts in San Francisco - Double Delight and There Is No Try.md
+++ b/notes/socials/2025-08-03 Hearts in San Francisco - Double Delight and There Is No Try.md
@@ -1,7 +1,6 @@
 ---
 title: "Hearts in San Francisco - Double Delight and There Is No Try"
 pubDate: August 3, 2025
-series: hearts-in-san-francisco
 tags: [san-francisco, hearts-in-san-francisco, public-art, union-square]
 locations:
  - [37.7875893,-122.4071575]

--- a/notes/socials/2025-08-19 Hearts in San Francisco - ColorFall of Hope.md
+++ b/notes/socials/2025-08-19 Hearts in San Francisco - ColorFall of Hope.md
@@ -1,7 +1,6 @@
 ---
 title: "Hearts in San Francisco - ColorFall of Hope"
 pubDate: August 19, 2025
-series: hearts-in-san-francisco
 tags: [san-francisco, hearts-in-san-francisco, public-art, castro]
 locations:
  - [37.760683, -122.434862]

--- a/notes/socials/2026-03-05 Hearts in San Francisco - Bae Area.md
+++ b/notes/socials/2026-03-05 Hearts in San Francisco - Bae Area.md
@@ -1,7 +1,6 @@
 ---
 title: "Hearts in San Francisco - Bae Area"
 pubDate: March 5, 2026
-series: hearts-in-san-francisco
 tags: [san-francisco, hearts-in-san-francisco, public-art, downtown, sfmoma]
 locations:
  - [37.788597,-122.401817]

--- a/notes/socials/Hearts in San Francisco.md
+++ b/notes/socials/Hearts in San Francisco.md
@@ -1,6 +1,5 @@
 ---
 title: Hearts in San Francisco
-type: series
 pubDate: 2025-07-12
 description: Encounters with the Hearts in San Francisco public art project around the city.
 ---

--- a/src/components/Notes.astro
+++ b/src/components/Notes.astro
@@ -37,26 +37,6 @@ export async function getNotes(options?: { keepIf?: (note: any) => boolean }) {
   const nowDate = new Date();
   const tags = {};
 
-  // Pre-scan: identify series definition files (type: series) → seriesId -> seriesSlug
-  const seriesDefBySlug = {};
-  for (const note of notes) {
-    if (note.frontmatter?.type === 'series') {
-      const slug = getSlugForNote(note);
-      const seriesId = slug.substring(slug.lastIndexOf('/') + 1);
-      seriesDefBySlug[seriesId] = slug;
-    }
-  }
-
-  // Pre-scan: group series member notes by series ID
-  const seriesMembersBySlug = {};
-  for (const note of notes) {
-    const seriesId = note.frontmatter?.series;
-    if (seriesId) {
-      if (!seriesMembersBySlug[seriesId]) seriesMembersBySlug[seriesId] = [];
-      seriesMembersBySlug[seriesId].push(note);
-    }
-  }
-
   // Convert notes to more usable type, and sort them
   let results: any[] = []; // TODO: define type
   for (const note of notes) {
@@ -72,29 +52,6 @@ export async function getNotes(options?: { keepIf?: (note: any) => boolean }) {
     }
     if (typeof pubDate === 'string' && pubDate.length === 0) {
       console.log("pubDate:", pubDate, "for:", note.file, "this will lead to complaints from the router later")
-    }
-
-    // Series definition files are added in a separate pass below
-    if (note.frontmatter?.type === 'series') continue;
-
-    // Handle series member entries
-    const seriesId = note.frontmatter?.series;
-    if (seriesId && seriesDefBySlug[seriesId]) {
-      // Series definition exists: suppress standalone page, generate redirects
-      const seriesSlug = seriesDefBySlug[seriesId];
-      const anchor = slug.substring(slug.lastIndexOf('/') + 1);
-      const redirectTarget = `${seriesSlug}#${anchor}`;
-      results.push({ params: { slug }, props: { type: 'redirect', redirectTo: redirectTarget } });
-      if (note.frontmatter?.aliases) {
-        for (const alias of note.frontmatter.aliases) {
-          results.push({ params: { slug: alias }, props: { type: 'redirect', redirectTo: redirectTarget } });
-        }
-      }
-      continue;
-    }
-    if (seriesId) {
-      // Series definition missing: warn and publish standalone (falls through to normal processing)
-      console.error(`[series] "${note.file}" references series "${seriesId}" but no series definition file found. Publishing standalone.`);
     }
 
     const isDraft = ''+((pubDate==="" || pubDate === undefined || typeof pubDate === 'undefined' || new Date(pubDate) > nowDate) && !/readme.md$/.test(note.file));
@@ -119,27 +76,6 @@ export async function getNotes(options?: { keepIf?: (note: any) => boolean }) {
         }
       }
     }
-  }
-
-  // Add series definition pages with their sorted member notes as props
-  for (const note of notes) {
-    if (note.frontmatter?.type !== 'series') continue;
-    const slug = getSlugForNote(note);
-    const type = getTypeForNote(note);
-    const name = getNameForNote(note);
-    const seriesId = slug.substring(slug.lastIndexOf('/') + 1);
-    const members = (seriesMembersBySlug[seriesId] || []).sort((a, b) => {
-      const aDate = new Date(getPubDateForNote(a) || '1970/1/1').getTime();
-      const bDate = new Date(getPubDateForNote(b) || '1970/1/1').getTime();
-      return aDate - bDate; // chronological
-    });
-    const pubDate = getPubDateForNote(note);
-    const nowDate = new Date();
-    const isDraft = ''+((pubDate === undefined || pubDate === '' || new Date(pubDate) > nowDate));
-    results.push({
-      params: { slug, type, name, pubDate, isDraft },
-      props: { ...note, seriesMembers: members }
-    });
   }
 
   for (const tag of Object.keys(tags)) {

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -16,23 +16,8 @@ const slug = Astro.props.slug || getSlugForNote(Astro.props);
 let type = slug.substring(0, slug.indexOf("/", 1)); // "socials", "books", "posts" or "tags"
 if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
 const tag = type === "tags" ? slug.substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
-const isSeriesPage = Astro.props.frontmatter?.type === 'series';
-const seriesMembers = Astro.props.seriesMembers || [];
-title = isSeriesPage ? (Astro.props.frontmatter?.title || title) : tag;
-console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}, isSeriesPage=${isSeriesPage}`);
-
-// Prepare series entries for rendering (done here so MemberContent is in scope for the template)
-const seriesEntries = seriesMembers.map((member) => {
-  const d = new Date(member.frontmatter.pubDate);
-  const anchor = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
-  const memberSlug = getSlugForNote(member);
-  const slugAnchor = memberSlug.substring(memberSlug.lastIndexOf('/') + 1);
-  const fullTitle = member.frontmatter.title;
-  const tocTitle = fullTitle.startsWith(title)
-    ? fullTitle.slice(title.length).replace(/^\s*[-–—]\s*/, '') || fullTitle
-    : fullTitle;
-  return { member, MemberContent: member.Content, anchor, slugAnchor, tocTitle };
-});
+title = tag;
+console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 
 let notes = [];
 function hasReview(note) {
@@ -64,22 +49,16 @@ async function buildMap(items, getFrontmatter, filename) {
   return filename;
 }
 
-let mapFilename = '', seriesMapFilename = '';
-if (isSeriesPage) {
-  const seriesSlugName = slug.substring(slug.lastIndexOf('/') + 1);
-  seriesMapFilename = await buildMap(seriesMembers, m => m.frontmatter, `map-series-${seriesSlugName}.png`);
-}
-if (!isSeriesPage) {
-  notes = await getNotes({ keepIf: (note) => {
+let mapFilename = '';
+notes = await getNotes({ keepIf: (note) => {
     return type === 'tags'
       ? note.props.frontmatter?.tags?.indexOf(tag) >= 0 && note.params.isDraft != 'true'
       : note.params.type === type && !/readme.md$/.test(note.props.file)
     }});
 
-  // TODO: Create separate maps for [san-francisco, new-york, and tags], use that to also generate the filenames
-  const filename = type === 'tags' ? `map-tags-${tag}.png` : `map-${type}-san-francisco.png`;
-  mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
-}
+// TODO: Create separate maps for [san-francisco, new-york, and tags], use that to also generate the filenames
+const filename = type === 'tags' ? `map-tags-${tag}.png` : `map-${type}-san-francisco.png`;
+mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
 ---
 
 <html lang="en">
@@ -134,35 +113,9 @@ if (!isSeriesPage) {
           {heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
         </div>
         <div class="prose">
-          {isSeriesPage && <h1>{title}</h1>}
           <slot />
           <hr />
-          {isSeriesPage && (
-            <div class="series">
-              {seriesMapFilename && (
-                <div class="map">
-                  <img src={'/' + seriesMapFilename} alt="Map of the articles in this series" />
-                </div>
-              )}
-              <ol>
-                {seriesEntries.map(({ member, anchor, tocTitle }) => (
-                  <li><a href={`#${anchor}`}>{tocTitle}</a> <FormattedDate date={new Date(member.frontmatter.pubDate)} /></li>
-                ))}
-              </ol>
-              <hr />
-              {seriesEntries.map(({ member, MemberContent, anchor, slugAnchor }) => (
-                <section id={anchor}>
-                  <span id={slugAnchor}></span>
-                  <h2>{member.frontmatter.title}</h2>
-                  <p class="date"><FormattedDate date={new Date(member.frontmatter.pubDate)} /> <a href={`#${anchor}`} class="anchor-link" title="Link to this section">#</a></p>
-                  <MemberContent />
-                  <hr />
-                </section>
-              ))}
-            </div>
-          )}
-          {!isSeriesPage && (
-            <div class="list">
+          <div class="list">
               <div>There are {notes.length} {type != 'tags' ? type : `pages about ${tag}`}:</div>
               {!mapFilename && (
                 // If there's no map, show one long list
@@ -211,8 +164,7 @@ if (!isSeriesPage) {
                 <hr/>
               )}
             <hr/>
-            </div>
-          )}
+          </div>
           <div class="date">
             {
               <div class="last-updated-on">

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -26,20 +26,19 @@ const slug = Astro.params.slug || getSlugForNote(post);
 const type = slug.substring(0, slug.indexOf("/", 1));
 const isRedirect = typeof post.redirectTo != 'undefined' && post.redirectTo.length > 0;
 const isTag = 'tags' === type || 'tag' === type;
-const isSeriesPage = post.frontmatter?.type === 'series';
 
 console.log(`Rendering ${slug} (${post.file}) with pubDate: ${pubDate}, type: ${type} isReadme: ${isReadme}, isRedirect: ${isRedirect}, isTag: ${isTag} to ${JSON.stringify(post)}`);
 ---
 
-{(pubDate && !isSeriesPage &&
+{(pubDate &&
 <NotePost {...post} pubDate={pubDate} title={post.frontmatter.title} description={post.frontmatter.description} >
   <Content  components={{ PullQuote }}/>
 </NotePost>
 )}
-{( (isReadme || isTag || isSeriesPage) &&
+{( (isReadme || isTag) &&
   <meta charset="utf-8"/>
   <IndexPage {...post} >
-    {((isReadme || isSeriesPage) && <article><Content /></article>)}
+    {(isReadme && <article><Content /></article>)}
   </IndexPage>
 )}
 


### PR DESCRIPTION
Removes all series-specific code (pre-scans, member suppression/redirects, series page emission, IndexPage series rendering) and the series: frontmatter field from member notes. The Hearts in San Francisco definition file loses its type: series marker and becomes a regular social post.