### PR TITLE
Series pages via tag content files

### DIFF
--- a/notes/socials/2025-07-12 Hearts in San Francisco statues.md
+++ b/notes/socials/2025-07-12 Hearts in San Francisco statues.md
@@ -14,7 +14,6 @@ locations:
  - [37.788185,-122.408212]
 aliases:
   - /socials/hearts-in-san-francisco-statues/
-  - /socials/2025-07-12-hearts-in-san-francisco-statues/
   - /socials/2025-07-13-hearts-in-san-francisco-statues
 ---
 

--- a/notes/tags/hearts-in-san-francisco.md
+++ b/notes/tags/hearts-in-san-francisco.md
@@ -4,6 +4,7 @@ pubDate: 2025-07-12
 description: Encounters with the Hearts in San Francisco public art project around the city.
 aliases: [socials/hearts-in-san-francisco]
 expandNotes: true
+sortOrder: asc
 ---
 
 If you've ever spent some time in San Francisco you've probably seen some of these large heart statues, like this one on Union Square:

--- a/notes/tags/hearts-in-san-francisco.md
+++ b/notes/tags/hearts-in-san-francisco.md
@@ -1,7 +1,9 @@
 ---
 title: Hearts in San Francisco
+tags: [hearts-in-san-francisco]
 pubDate: 2025-07-12
 description: Encounters with the Hearts in San Francisco public art project around the city.
+aliases: [socials/hearts-in-san-francisco]
 ---
 
 If you've ever spent some time in San Francisco you've probably seen some of these large heart statues, like this one on Union Square:

--- a/notes/tags/hearts-in-san-francisco.md
+++ b/notes/tags/hearts-in-san-francisco.md
@@ -3,6 +3,7 @@ title: Hearts in San Francisco
 pubDate: 2025-07-12
 description: Encounters with the Hearts in San Francisco public art project around the city.
 aliases: [socials/hearts-in-san-francisco]
+expandNotes: true
 ---
 
 If you've ever spent some time in San Francisco you've probably seen some of these large heart statues, like this one on Union Square:

--- a/notes/tags/hearts-in-san-francisco.md
+++ b/notes/tags/hearts-in-san-francisco.md
@@ -1,6 +1,5 @@
 ---
 title: Hearts in San Francisco
-tags: [hearts-in-san-francisco]
 pubDate: 2025-07-12
 description: Encounters with the Hearts in San Francisco public art project around the city.
 aliases: [socials/hearts-in-san-francisco]

--- a/src/components/NoteEntry.astro
+++ b/src/components/NoteEntry.astro
@@ -1,0 +1,44 @@
+---
+import FormattedDate from './FormattedDate.astro';
+import AlsoOn from './AlsoOn.astro';
+
+const {
+  pubDate,
+  updatedDate,
+  permalink,
+  alsoOn,
+  location,
+  tags = [],
+  tagCounts = {},
+  filterTag,
+} = Astro.props;
+
+const displayTags = (tags as string[]).filter((t: string) => t !== filterTag);
+const tc = tagCounts as Record<string, number>;
+---
+
+<div class="note-meta">
+  {pubDate && <FormattedDate date={new Date(pubDate)} />}
+  {updatedDate && <div class="last-updated-on">Last updated on <FormattedDate date={updatedDate} /></div>}
+  {permalink && <> <a href={permalink}>#</a></>}
+</div>
+<AlsoOn links={alsoOn} />
+<slot />
+{location && (
+  <p>Location of this post on
+    <a href={`https://www.google.com/maps/@${location[0]},${location[1]},17z`} target="_blank">
+      Google Maps
+      <svg width="12px" height="12px" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true">
+        <path stroke="#535358" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M22 3h7v7M27.5 4.5L20 12M17 5H8a3 3 0 00-3 3v16a3 3 0 003 3h16a3 3 0 003-3v-9"/>
+      </svg>
+      <span class="sr-only"> opens a new window</span>
+    </a>
+  </p>
+)}
+{displayTags.length > 0 && (
+  <div class="tags">
+    {displayTags.map((t: string) => (
+      <a href={`/tags/${t}`}>{t}{tc[t] ? ` (${tc[t]})` : ''}</a>
+    ))}
+  </div>
+)}

--- a/src/components/NoteEntry.astro
+++ b/src/components/NoteEntry.astro
@@ -23,6 +23,17 @@ const tc = tagCounts as Record<string, number>;
   {updatedDate && <div class="last-updated-on">Last updated on <FormattedDate date={updatedDate} /></div>}
   {permalink && <> <a href={permalink}>#</a></>}
 </div>
+
+<style>
+  .note-meta {
+    margin-bottom: 0.5em;
+    color: rgb(var(--gray));
+    text-align: center;
+  }
+  .last-updated-on {
+    font-style: italic;
+  }
+</style>
 {hr && <hr />}
 <AlsoOn links={alsoOn} />
 <slot />

--- a/src/components/NoteEntry.astro
+++ b/src/components/NoteEntry.astro
@@ -33,6 +33,14 @@ const tc = tagCounts as Record<string, number>;
   .last-updated-on {
     font-style: italic;
   }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 </style>
 {hr && <hr />}
 <AlsoOn links={alsoOn} />
@@ -49,9 +57,9 @@ const tc = tagCounts as Record<string, number>;
   </p>
 )}
 {displayTags.length > 0 && (
-  <div class="tags">
+  <ul class="tags">
     {displayTags.map((t: string) => (
-      <a href={`/tags/${t}`}>{t}{tc[t] ? ` (${tc[t]})` : ''}</a>
+      <li><a href={`/tags/${t}`}>{t}{tc[t] ? ` (${tc[t]})` : ''}</a></li>
     ))}
-  </div>
+  </ul>
 )}

--- a/src/components/NoteEntry.astro
+++ b/src/components/NoteEntry.astro
@@ -11,6 +11,7 @@ const {
   tags = [],
   tagCounts = {},
   filterTag,
+  hr = false,
 } = Astro.props;
 
 const displayTags = (tags as string[]).filter((t: string) => t !== filterTag);
@@ -22,6 +23,7 @@ const tc = tagCounts as Record<string, number>;
   {updatedDate && <div class="last-updated-on">Last updated on <FormattedDate date={updatedDate} /></div>}
   {permalink && <> <a href={permalink}>#</a></>}
 </div>
+{hr && <hr />}
 <AlsoOn links={alsoOn} />
 <slot />
 {location && (

--- a/src/components/Notes.astro
+++ b/src/components/Notes.astro
@@ -79,9 +79,11 @@ export async function getNotes(options?: { keepIf?: (note: any) => boolean }) {
   }
 
   for (const tag of Object.keys(tags)) {
-    // Create a tag page for each tag
+    // Create a tag page for each tag, unless a file-based tag page already exists
     const tagSlug = 'tags/'+tag.replace(/\s/g, '-').toLowerCase(); // normalize tag slug
-    results.push({ params: { slug: tagSlug }, props: { type: "tag", tag, slug: tagSlug, notes: tags[tag] } });
+    if (!results.some(r => r.params.slug === '/'+tagSlug)) {
+      results.push({ params: { slug: tagSlug }, props: { type: "tag", tag, slug: tagSlug, notes: tags[tag] } });
+    }
   }
 
   if (process.env.NODE_ENV === 'production') {

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -62,6 +62,7 @@ notes = allNotes.filter(note =>
     ? note.props.frontmatter?.tags?.indexOf(tag) >= 0 && note.params.isDraft != 'true'
     : note.params.type === type && !/readme.md$/.test(note.props.file)
 );
+if (expandNotes && Astro.props.frontmatter?.sortOrder === 'asc') notes = notes.toReversed();
 
 // TODO: Create separate maps for [san-francisco, new-york, and tags], use that to also generate the filenames
 const filename = type === 'tags' ? `map-tags-${tag}.png` : `map-${type}-san-francisco.png`;

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -112,11 +112,6 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
       .last-updated-on {
         font-style: italic;
       }
-      .tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5em;
-      }
     </style>
   </head>
 

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -16,7 +16,7 @@ const slug = Astro.props.slug || getSlugForNote(Astro.props);
 let type = slug.substring(0, slug.indexOf("/", 1)); // "socials", "books", "posts" or "tags"
 if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
 const tag = type === "tags" ? slug.replace(/^\//, '').substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
-const isSeriesPage = type === 'tags' && !!Astro.props.file;
+const hasTagContent = type === 'tags' && !!Astro.props.file;
 title = tag;
 console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 
@@ -116,22 +116,34 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
         <div class="prose">
           <slot />
           <hr />
-          {isSeriesPage ? (
+          {hasTagContent ? (
             <>
               <nav>
                 <ol>
                   {notes.map(note => {
                     const sectionId = note.params.slug.split('/').filter(Boolean).pop();
-                    return <li><a href={`#${sectionId}`}>{note.props.frontmatter.title}</a></li>;
+                    return (
+                      <li>
+                        <a href={`#${sectionId}`}>{note.props.frontmatter.title}</a>
+                        {note.params.pubDate && <> — <FormattedDate date={new Date(note.params.pubDate)} /></>}
+                      </li>
+                    );
                   })}
                 </ol>
               </nav>
+              {mapFilename && <div class="map"><img src={'/'+mapFilename} /></div>}
               {notes.map(note => {
                 const NoteContent = note.props.Content;
                 const sectionId = note.params.slug.split('/').filter(Boolean).pop();
+                const tags = note.props.frontmatter.tags || [];
                 return (
                   <section id={sectionId}>
-                    <h2><a href={note.params.slug}>{note.props.frontmatter.title}</a></h2>
+                    <h2>{note.props.frontmatter.title}</h2>
+                    <div class="note-meta">
+                      {note.params.pubDate && <FormattedDate date={new Date(note.params.pubDate)} />}
+                      {' '}<a href={`#${sectionId}`}>#</a>
+                      {tags.length > 0 && <span class="tags">{tags.map(t => <a href={`/tags/${t}`}>{t}</a>)}</span>}
+                    </div>
                     <NoteContent />
                   </section>
                 );

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -15,7 +15,7 @@ let { title, description, heroImage } = Astro.props;
 const slug = Astro.props.slug || getSlugForNote(Astro.props);
 let type = slug.substring(0, slug.indexOf("/", 1)); // "socials", "books", "posts" or "tags"
 if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
-const tag = type === "tags" ? slug.substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
+const tag = type === "tags" ? slug.replace(/^\//, '').substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
 title = tag;
 console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -6,6 +6,7 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import StarRating from '../components/StarRating.astro'
 import { getSlugForNote, getNotes } from '../components/Notes.astro';
+import AlsoOn from '../components/AlsoOn.astro';
 import path from 'path';
 import fs from "fs/promises";
 
@@ -126,11 +127,12 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
           {heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
         </div>
         <div class="prose">
+          {expandNotes && <h1>{title}</h1>}
           <slot />
+          {expandNotes && <AlsoOn links={Astro.props.frontmatter?.alsoOn} />}
           <hr />
           {expandNotes ? (
             <>
-              <h1>{title}</h1>
               <nav>
                 <ol>
                   {notes.map(note => {

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -17,6 +17,7 @@ let type = slug.substring(0, slug.indexOf("/", 1)); // "socials", "books", "post
 if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
 const tag = type === "tags" ? slug.replace(/^\//, '').substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
 const hasTagContent = type === 'tags' && !!Astro.props.file;
+const expandNotes = hasTagContent && !!Astro.props.frontmatter?.expandNotes;
 title = tag;
 console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 
@@ -116,7 +117,7 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
         <div class="prose">
           <slot />
           <hr />
-          {hasTagContent ? (
+          {expandNotes ? (
             <>
               <nav>
                 <ol>

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -18,7 +18,7 @@ if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
 const tag = type === "tags" ? slug.replace(/^\//, '').substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
 const hasTagContent = type === 'tags' && !!Astro.props.file;
 const expandNotes = hasTagContent && !!Astro.props.frontmatter?.expandNotes;
-title = tag;
+title = Astro.props.frontmatter?.title || tag;
 console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 
 let notes = [];
@@ -52,11 +52,16 @@ async function buildMap(items, getFrontmatter, filename) {
 }
 
 let mapFilename = '';
-notes = await getNotes({ keepIf: (note) => {
-    return type === 'tags'
-      ? note.props.frontmatter?.tags?.indexOf(tag) >= 0 && note.params.isDraft != 'true'
-      : note.params.type === type && !/readme.md$/.test(note.props.file)
-    }});
+const allNotes = await getNotes();
+const tagCounts: Record<string, number> = {};
+allNotes.forEach(n => (n.props.frontmatter?.tags || []).forEach((t: string) => {
+  tagCounts[t] = (tagCounts[t] || 0) + 1;
+}));
+notes = allNotes.filter(note =>
+  type === 'tags'
+    ? note.props.frontmatter?.tags?.indexOf(tag) >= 0 && note.params.isDraft != 'true'
+    : note.params.type === type && !/readme.md$/.test(note.props.file)
+);
 
 // TODO: Create separate maps for [san-francisco, new-york, and tags], use that to also generate the filenames
 const filename = type === 'tags' ? `map-tags-${tag}.png` : `map-${type}-san-francisco.png`;
@@ -104,6 +109,11 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
       .last-updated-on {
         font-style: italic;
       }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
     </style>
   </head>
 
@@ -119,6 +129,7 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
           <hr />
           {expandNotes ? (
             <>
+              <h1>{title}</h1>
               <nav>
                 <ol>
                   {notes.map(note => {
@@ -147,7 +158,13 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
                         {' '}<a href={`#${sectionId}`}>#</a>
                       </div>
                       <NoteContent />
-                      {tags.length > 0 && <div class="tags">{tags.map(t => <a href={`/tags/${t}`}>{t}</a>)}</div>}
+                      {tags.filter(t => t !== tag).length > 0 && (
+                        <div class="tags">
+                          {tags.filter((t: string) => t !== tag).map((t: string) => (
+                            <a href={`/tags/${t}`}>{t} ({tagCounts[t] || 0})</a>
+                          ))}
+                        </div>
+                      )}
                     </section>
                   </>
                 );

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -7,6 +7,7 @@ import FormattedDate from '../components/FormattedDate.astro';
 import StarRating from '../components/StarRating.astro'
 import { getSlugForNote, getNotes } from '../components/Notes.astro';
 import AlsoOn from '../components/AlsoOn.astro';
+import NoteEntry from '../components/NoteEntry.astro';
 import path from 'path';
 import fs from "fs/promises";
 
@@ -150,24 +151,22 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
               {notes.map(note => {
                 const NoteContent = note.props.Content;
                 const sectionId = note.params.slug.split('/').filter(Boolean).pop();
-                const tags = note.props.frontmatter.tags || [];
                 return (
                   <>
                     <hr />
                     <section id={sectionId}>
                       <h2>{note.props.frontmatter.title}</h2>
-                      <div class="note-meta">
-                        {note.params.pubDate && <FormattedDate date={new Date(note.params.pubDate)} />}
-                        {' '}<a href={`#${sectionId}`}>#</a>
-                      </div>
-                      <NoteContent />
-                      {tags.filter(t => t !== tag).length > 0 && (
-                        <div class="tags">
-                          {tags.filter((t: string) => t !== tag).map((t: string) => (
-                            <a href={`/tags/${t}`}>{t} ({tagCounts[t] || 0})</a>
-                          ))}
-                        </div>
-                      )}
+                      <NoteEntry
+                        pubDate={note.params.pubDate}
+                        permalink={`#${sectionId}`}
+                        alsoOn={note.props.frontmatter.alsoOn}
+                        location={note.props.frontmatter.location || note.props.frontmatter.locations?.[0]}
+                        tags={note.props.frontmatter.tags}
+                        tagCounts={tagCounts}
+                        filterTag={tag}
+                      >
+                        <NoteContent />
+                      </NoteEntry>
                     </section>
                   </>
                 );

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -138,17 +138,21 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
                 const sectionId = note.params.slug.split('/').filter(Boolean).pop();
                 const tags = note.props.frontmatter.tags || [];
                 return (
-                  <section id={sectionId}>
-                    <h2>{note.props.frontmatter.title}</h2>
-                    <div class="note-meta">
-                      {note.params.pubDate && <FormattedDate date={new Date(note.params.pubDate)} />}
-                      {' '}<a href={`#${sectionId}`}>#</a>
-                      {tags.length > 0 && <span class="tags">{tags.map(t => <a href={`/tags/${t}`}>{t}</a>)}</span>}
-                    </div>
-                    <NoteContent />
-                  </section>
+                  <>
+                    <hr />
+                    <section id={sectionId}>
+                      <h2>{note.props.frontmatter.title}</h2>
+                      <div class="note-meta">
+                        {note.params.pubDate && <FormattedDate date={new Date(note.params.pubDate)} />}
+                        {' '}<a href={`#${sectionId}`}>#</a>
+                      </div>
+                      <NoteContent />
+                      {tags.length > 0 && <div class="tags">{tags.map(t => <a href={`/tags/${t}`}>{t}</a>)}</div>}
+                    </section>
+                  </>
                 );
               })}
+              <hr />
             </>
           ) : (
           <div class="list">

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -16,6 +16,7 @@ const slug = Astro.props.slug || getSlugForNote(Astro.props);
 let type = slug.substring(0, slug.indexOf("/", 1)); // "socials", "books", "posts" or "tags"
 if (type.charAt(0) === '/') type = type.substring(1); // remove leading slash
 const tag = type === "tags" ? slug.replace(/^\//, '').substring(type.length + 1) : ""; // e.g. "javascript" or "react" or "astro"
+const isSeriesPage = type === 'tags' && !!Astro.props.file;
 title = tag;
 console.log(`IndexPage.astro: type=${type}, slug=${slug}, tag=${tag}`);
 
@@ -115,6 +116,28 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
         <div class="prose">
           <slot />
           <hr />
+          {isSeriesPage ? (
+            <>
+              <nav>
+                <ol>
+                  {notes.map(note => {
+                    const sectionId = note.params.slug.split('/').filter(Boolean).pop();
+                    return <li><a href={`#${sectionId}`}>{note.props.frontmatter.title}</a></li>;
+                  })}
+                </ol>
+              </nav>
+              {notes.map(note => {
+                const NoteContent = note.props.Content;
+                const sectionId = note.params.slug.split('/').filter(Boolean).pop();
+                return (
+                  <section id={sectionId}>
+                    <h2><a href={note.params.slug}>{note.props.frontmatter.title}</a></h2>
+                    <NoteContent />
+                  </section>
+                );
+              })}
+            </>
+          ) : (
           <div class="list">
               <div>There are {notes.length} {type != 'tags' ? type : `pages about ${tag}`}:</div>
               {!mapFilename && (
@@ -165,6 +188,7 @@ mapFilename = await buildMap(notes, n => n.props?.frontmatter, filename);
               )}
             <hr/>
           </div>
+          )}
           <div class="date">
             {
               <div class="last-updated-on">

--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -3,12 +3,10 @@ import type { CollectionEntry } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
-import FormattedDate from '../components/FormattedDate.astro';
 import StarRating from '../components/StarRating.astro';
 import { getTypeForNote, getSlugForNote, getNotes } from '../components/Notes.astro';
 import AlsoOn from '../components/AlsoOn.astro';
 import NoteEntry from '../components/NoteEntry.astro';
-import { Picture } from 'astro:assets';
 
 type Props = CollectionEntry<'blog'>['data'] & {
   frontmatter: {

--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -7,6 +7,7 @@ import FormattedDate from '../components/FormattedDate.astro';
 import StarRating from '../components/StarRating.astro';
 import { getTypeForNote, getSlugForNote, getNotes } from '../components/Notes.astro';
 import AlsoOn from '../components/AlsoOn.astro';
+import NoteEntry from '../components/NoteEntry.astro';
 import { Picture } from 'astro:assets';
 
 type Props = CollectionEntry<'blog'>['data'] & {
@@ -129,48 +130,30 @@ await getNotes({ keepIf: (other) => {
 				</div>
 				<div class="prose">
 					<div class="title">
-						<div class="date">
-							<FormattedDate date={new Date(pubDate)} />
-							{
-								updatedDate && (
-									<div class="last-updated-on">
-										Last updated on <FormattedDate date={updatedDate} />
-									</div>
-								)
-							}
-						</div>
 						<h1>{title}</h1>
 						<hr />
 					</div>
-					<div class="frontmatter">
-						{type === "books" ? (
-						  <ul class="props">
-							<!-- Get rid of the red squiggles on frontmatter -->
-							<li>Author: {frontmatter?.author}</li>
-							<li>Page count: {frontmatter.pageCount}</li>
-							<li>Started on: {frontmatter.startedDate}</li>
-							<li>Finished on: {frontmatter.finishedDate}</li>
-							<li>Rating: {frontmatter.rating} out of 5 stars</li> <!-- render star rating -->
-							<StarRating rating={frontmatter.rating} /><br/>
-							<li><AlsoOn links={[frontmatter.link]} /></li>
-						  </ul>
-						  <hr/>
-						) : ( "" )}
-						
-						<AlsoOn links={frontmatter?.alsoOn} />
-					</div>
-					<slot />
-					{location && (
-						<p>Location of this post on  
-							<a href={`https://www.google.com/maps/@${location[0]},${location[1]},17z`} target="_blank">
-								Google Maps
-								<svg width="12px" height="12px" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true">
-									<path stroke="#535358" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M22 3h7v7M27.5 4.5L20 12M17 5H8a3 3 0 00-3 3v16a3 3 0 003 3h16a3 3 0 003-3v-9"/>
-								</svg>
-								<span class="sr-only"> opens a new window</span>
-							</a>
-						</p>
+					{type === "books" && (
+					  <ul class="props">
+						<li>Author: {frontmatter?.author}</li>
+						<li>Page count: {frontmatter.pageCount}</li>
+						<li>Started on: {frontmatter.startedDate}</li>
+						<li>Finished on: {frontmatter.finishedDate}</li>
+						<li>Rating: {frontmatter.rating} out of 5 stars</li>
+						<StarRating rating={frontmatter.rating} /><br/>
+						<li><AlsoOn links={[frontmatter.link]} /></li>
+					  </ul>
+					  <hr/>
 					)}
+					<NoteEntry
+						pubDate={pubDate}
+						updatedDate={updatedDate}
+						alsoOn={frontmatter?.alsoOn}
+						location={location}
+						tags={frontmatter?.tags}
+					>
+						<slot />
+					</NoteEntry>
 				</div>
 			</article>
 		{Object.keys(otherNotesForTags).length > 0 && (

--- a/src/layouts/NotePost.astro
+++ b/src/layouts/NotePost.astro
@@ -131,7 +131,6 @@ await getNotes({ keepIf: (other) => {
 				<div class="prose">
 					<div class="title">
 						<h1>{title}</h1>
-						<hr />
 					</div>
 					{type === "books" && (
 					  <ul class="props">
@@ -151,6 +150,7 @@ await getNotes({ keepIf: (other) => {
 						alsoOn={frontmatter?.alsoOn}
 						location={location}
 						tags={frontmatter?.tags}
+						hr={true}
 					>
 						<slot />
 					</NoteEntry>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -30,7 +30,7 @@ const isTag = 'tags' === type || 'tag' === type;
 console.log(`Rendering ${slug} (${post.file}) with pubDate: ${pubDate}, type: ${type} isReadme: ${isReadme}, isRedirect: ${isRedirect}, isTag: ${isTag} to ${JSON.stringify(post)}`);
 ---
 
-{(pubDate &&
+{(pubDate && !isTag &&
 <NotePost {...post} pubDate={pubDate} title={post.frontmatter.title} description={post.frontmatter.description} >
   <Content  components={{ PullQuote }}/>
 </NotePost>
@@ -38,7 +38,7 @@ console.log(`Rendering ${slug} (${post.file}) with pubDate: ${pubDate}, type: ${
 {( (isReadme || isTag) &&
   <meta charset="utf-8"/>
   <IndexPage {...post} >
-    {(isReadme && <article><Content /></article>)}
+    {((isReadme || isTag) && Content && <article><Content /></article>)}
   </IndexPage>
 )}
 


### PR DESCRIPTION
## Summary

- Adds support for `notes/tags/<tag>.md` files that serve as authored content pages for a tag
- When `expandNotes: true` is set in frontmatter, tagged notes are embedded as sections rather than listed as links
- `sortOrder: asc/desc` controls chronological vs reverse-chronological ordering of embedded notes
- Extracts shared `NoteEntry.astro` component used by both standalone note pages and embedded tag page notes
- Removes dead `FormattedDate` and `Picture` imports from `NotePost.astro`

## New frontmatter fields (in `notes/tags/<tag>.md`)

| Field | Values | Effect |
|---|---|---|
| `expandNotes` | `true` | Embed notes as sections instead of list |
| `sortOrder` | `asc` / `desc` | Chronological / newest-first (default) |
| `alsoOn` | `[url, ...]` | Social links rendered on the tag page |

## Test plan

- [ ] `/tags/hearts-in-san-francisco` shows title, intro, alsoOn, TOC, map, embedded notes in chronological order
- [ ] Each embedded note shows date, `#` permalink, content, tags (excluding current tag) with counts
- [ ] `/tags/san-francisco` (auto-generated, no tag file) still shows plain list
- [ ] Standalone note pages still render correctly with date below title, above `<hr/>`
- [ ] `/socials/hearts-in-san-francisco` redirects to `/tags/hearts-in-san-francisco`

🤖 Generated with [Claude Code](https://claude.com/claude-code)